### PR TITLE
Update README with vol location and fonts instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,52 @@
-# Repository to create docker images 
+# Repository to create docker images
 
 - GHC 8.6.5
 - Latex (all packages)
 
 # SSH Keys:
 
-Once you clone this repo, you should get into `ssh` and add your private / public keys to connect to Github or Bitbucket. 
-File `key` is the private key file which is **not** passphrase protected. File `key.pub` is your public key. 
+Once you clone this repo, you should get into `ssh` and add your private / public keys to connect to Github or Bitbucket.
+File `key` is the private key file which is **not** passphrase protected. File `key.pub` is your public key.
 
-# To create / launch an image 
+# To create / launch an image
 
 - File `./ghc865.sh` creates / launches a docker images with GHC 8.6.5.
-- File `./latex.sh` creates / launches a docker with texlive in its full version. 
+- File `./latex.sh` creates / launches a docker with texlive in its full version.
 
-All of the docker images will have a volume associated with it and mounted in `/vol`. 
-This is the directory where you should put all your persisten data. 
+All of the docker images will have a volume associated with it and mounted in `/vol`.
+This is the directory where you should put all your persisten data.
 
 # VS Code
 
 Install the extension "Remote - Containers" to attach the editor to the container.
 
+## Fonts formatting
+- In windows, install a font compatible with Powerline. This setup has been
+  tested with [Menlo for Powerline](https://github.com/abertsch/Menlo-for-Powerline)
+  and [JetBrains Mono](https://www.jetbrains.com/lp/mono/)
+
+- Set VS Code editor's font to the one you have installed. Typically it can be
+  done by navigating to `File > Preferences > Settings`, searching for `editor
+  font family` and adding the desired font to the list.
+
 # To create a key
 
-Run the following command inside the `ssh` directory, and just press enter when asked for a password. 
+Run the following command inside the `ssh` directory, and just press enter when asked for a password.
 
 ```bash
 ssh-keygen -t ed25519 -C <your_email> -f ./key
 ```
-# Where to find the files /vol in Windows 
+# Where to find the files /vol in Windows
+
+- Docker v19
 
 ```
 \\wsl$\docker-desktop-data\version-pack-data\community\docker
 ```
+
+- Docker v20
+```
+\\wsl$\docker-desktop-data\data\docker\volumes
+```
+
+Note: You can find the directory by typing `\\wsl$` in windows file manager.


### PR DESCRIPTION
This PR extends `README.md` with:
- Instructions on how to install fonts compatible with powerline
- Location of `/vol` directory for docker v20